### PR TITLE
Use random number for mutation iterations

### DIFF
--- a/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
+++ b/compiler-rt/lib/fuzzer/FuzzerLoop.cpp
@@ -863,7 +863,8 @@ void Fuzzer::MinimizeCrashLoop(const Unit &U) {
   while (!TimedOut() && TotalNumberOfRuns < Options.MaxNumberOfRuns) {
     MD.StartMutationSequence();
     memcpy(CurrentUnitData, U.data(), U.size());
-    for (int i = 0; i < (1 << (1 + (MD.GetRand().Rand() % Options.MutateDepth))); i++) {
+    int maxMutationIterations = (1 << (1 + (MD.GetRand().Rand() % Options.MutateDepth)));
+    for (int i = 0; i < maxMutationIterations; i++) {
       size_t NewSize = MD.Mutate(CurrentUnitData, U.size(), MaxMutationLen);
       assert(NewSize > 0 && NewSize <= MaxMutationLen);
       ExecuteCallback(CurrentUnitData, NewSize);


### PR DESCRIPTION
Use random numbers for mutation iteration and also skip intermediate inputs.